### PR TITLE
Added enhancement for custom dns servers and persist changes in localstorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,25 +96,37 @@
 </div>
 <p class="text-lg mx-auto mb-5 leading-relaxed max-w-xl dark:text-gray-300">Optimize your internet experience by finding
     the fastest DNS server for your location. Just click the button below to start the test.</p>
-<button id="checkButton"
+<button id="check-button"
         class="bg-green-500 text-white py-3 px-6 text-lg rounded-lg shadow-lg transform transition duration-300 ease-in-out hover:scale-105 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-700 focus:ring-opacity-50 mb-5 dark:bg-green-600 dark:hover:bg-green-800">
     Check DNS Speed
 </button>
 <div class="absolute top-5 right-5">
     <div class="group relative inline-block">
-        <button id="editButton"
+        <button id="edit-host-button"
                 class="bg-white text-2xl text-white bg-transparent border-none rounded-full w-10 h-10 flex justify-center items-center shadow-lg">
             🛠️
         </button>
-        <span class="pointer-events-none absolute top-full right-0 transform translate-y-2 w-max bg-black text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity">
+        <span class="pointer-events-none absolute top-0 right-12 transform translate-y-2 w-max bg-black text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity">
             Edit hosts list
         </span>
     </div>
 </div>
-<div id="loadingMessage" class="hidden"></div>
+<div class="absolute top-20 right-5">
+    <div class="group relative inline-block">
+        <button id="edit-dns-button"
+                class="bg-white text-2xl text-white bg-transparent border-none rounded-full w-10 h-10 flex justify-center items-center shadow-lg">
+            🌐️
+        </button>
+        <span class="pointer-events-none absolute top-0 right-12 transform translate-y-2 w-max bg-black text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity">
+            Edit dns list
+        </span>
+    </div>
+</div>
+<div id="loading-message" class="hidden"></div>
 <!-- Modal -->
-<div id="websiteModal" class="hidden fixed z-50 inset-0 flex items-center justify-center bg-black bg-opacity-60">
+<div id="website-modal" class="hidden fixed z-50 inset-0 flex items-center justify-center bg-black bg-opacity-60">
     <div class="modal-content relative bg-white pt-4 pb-2 px-4 rounded-lg shadow-xl w-full sm:w-11/12 md:w-1/2 mx-auto my-2 sm:my-4 overflow-hidden dark:bg-gray-700 dark:text-white">
+        <span id="reset-websites" class="absolute top-2 left-2 text-2xl font-bold text-gray-500 hover:text-black cursor-pointer p-1 dark:text-gray-200 dark:hover:text-white">↻</span>
         <span class="close absolute top-2 right-2 text-3xl font-bold text-gray-500 hover:text-black cursor-pointer p-1 dark:text-gray-200 dark:hover:text-white">×</span>
         <h2 class="text-2xl sm:text-3xl mb-2 sm:mb-4 font-semibold dark:text-gray-200">Edit DNS Test Hosts</h2>
         <p class="mb-2 sm:mb-4 text-base sm:text-lg leading-relaxed dark:text-gray-300">
@@ -123,7 +135,7 @@
         </p>
         <!-- Scrollable List Container -->
         <div class="overflow-auto max-h-[50vh] sm:max-h-[60vh]"> <!-- Adjust max height as needed -->
-            <ul id="websiteList" class="list-none p-0">
+            <ul id="website-list" class="list-none p-0">
                 <!-- Dynamic list items will be added here -->
             </ul>
         </div>
@@ -131,15 +143,47 @@
             <input type="text" id="newWebsite"
                    class="py-2 mr-2 px-4 w-3/4 border-2 border-gray-400 rounded focus:border-blue-500 focus:outline-none transition duration-200 ease-in-out placeholder-gray-600 dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-400"
                    placeholder="Add new hostname...">
-            <button id="addHostname"
+            <button id="add-host-name"
                     class="py-2 px-6 bg-green-500 text-white rounded hover:bg-green-600 text-lg dark:bg-green-700 dark:hover:bg-green-900">
                 Add
             </button>
         </div>
     </div>
 </div>
-<div id="dnsResults" aria-live="polite" class="mt-5 overflow-x-auto">
-    <table id="resultsTable" class="w-full border-collapse table-fixed">
+<div id="dns-modal" class="hidden fixed z-50 inset-0 flex items-center justify-center bg-black bg-opacity-60">
+    <div class="modal-content relative bg-white pt-4 pb-2 px-4 rounded-lg shadow-xl w-full sm:w-11/12 md:w-3/4 mx-auto my-2 sm:my-4 overflow-hidden dark:bg-gray-700 dark:text-white">
+        <span id="reset-dns" class="absolute top-2 left-2 text-2xl font-bold text-gray-500 hover:text-black cursor-pointer p-1 dark:text-gray-200 dark:hover:text-white">↻</span>
+        <span class="close absolute top-2 right-2 text-3xl font-bold text-gray-500 hover:text-black cursor-pointer p-1 dark:text-gray-200 dark:hover:text-white">×</span>
+        <h2 class="text-2xl sm:text-3xl mb-2 sm:mb-4 font-semibold dark:text-gray-200">Edit DNS Servers</h2>
+        <p class="mb-2 sm:mb-4 text-base sm:text-lg leading-relaxed dark:text-gray-300">
+            Add or remove DNS servers to tailor DNS server testing. Incorporate your own DNS servers to refine the
+            result of your DNS speed test.
+        </p>
+        <!-- Scrollable List Containers -->
+        <div class="overflow-auto max-h-[50vh] sm:max-h-[60vh]"> <!-- Adjust max height as needed -->
+            <ul id="dns-list" class="list-none p-0">
+                <!-- Dynamic list items will be added here -->
+            </ul>
+        </div>
+        <div class="flex mt-2 sm:mt-4 justify-center">
+            <input type="text" id="dns-name"
+                   class="py-2 mr-2 px-4 w-3/4 border-2 border-gray-400 rounded focus:border-blue-500 focus:outline-none transition duration-200 ease-in-out placeholder-gray-600 dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-400"
+                   placeholder="Display name...">
+            <input type="text" id="new-dns"
+                   class="py-2 mr-2 px-4 w-3/4 border-2 border-gray-400 rounded focus:border-blue-500 focus:outline-none transition duration-200 ease-in-out placeholder-gray-600 dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-400"
+                   placeholder="Add new dns...">
+            <input type="text" id="dns-ips"
+                   class="py-2 mr-2 px-4 w-3/4 border-2 border-gray-400 rounded focus:border-blue-500 focus:outline-none transition duration-200 ease-in-out placeholder-gray-600 dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-400"
+                   placeholder="Comma separated IP address...">
+            <button id="add-dns"
+                    class="py-2 px-6 bg-green-500 text-white rounded hover:bg-green-600 text-lg dark:bg-green-700 dark:hover:bg-green-900">
+                Add
+            </button>
+        </div>
+    </div>
+</div>
+<div id="dns-results" aria-live="polite" class="mt-5 overflow-x-auto">
+    <table id="results-table" class="w-full border-collapse table-fixed">
         <thead>
         <tr>
             <th class="w-1/3 py-2 px-4 text-left border-b border-gray-300 bg-blue-200 text-gray-700 cursor-pointer dark:bg-gray-800 dark:text-gray-200">
@@ -164,9 +208,9 @@
         </tbody>
     </table>
 </div>
-<div id="chartContainer" class="hidden w-4/5 mx-auto mt-5 hidden">
-    <canvas id="dnsChart" class="w-full h-96"></canvas>
-    <button id="resetZoom"
+<div id="chart-container" class="hidden w-4/5 mx-auto mt-5 hidden">
+    <canvas id="dns-chart" class="w-full h-96"></canvas>
+    <button id="reset-zoom"
             class="mt-3 bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 dark:bg-blue-700 dark:hover:bg-blue-800">
         Reset Zoom
     </button>


### PR DESCRIPTION
I chanced upon your tool [https://dnsspeedtest.online/](https://dnsspeedtest.online/) when I was trying to benchmark and compare my own Adguard server. However I realised I had to manually edit the `script.js` to put in a customised DNS server, so I decided to add these enhancements. Should also fix the issue with https://github.com/BrainicHQ/DoHSpeedTest/issues/5

1. Support custom DNS server in the web page and added a new icon to edit the dns servers.

![main_page](https://github.com/BrainicHQ/DoHSpeedTest/assets/44013904/03a5cae7-6811-4709-a3e8-ad9157349b36)
![dns_edit_page](https://github.com/BrainicHQ/DoHSpeedTest/assets/44013904/d3f74a1c-f2f1-4c6c-88ce-96df01ed25d1)
![added_dns_page](https://github.com/BrainicHQ/DoHSpeedTest/assets/44013904/2975506a-4f07-453f-8cd8-2a97037e4a48)

2. Saved the top websites and dns servers into localstorage so they are persisted through multiple sessions

It is currently deployed at [https://speed-doh.static.domains/](https://speed-doh.static.domains/).