### PR TITLE
fixed curly brace that rendered the site useless

### DIFF
--- a/script.js
+++ b/script.js
@@ -55,10 +55,9 @@ const dnsServers = [{
     name: "Google", url: "https://dns.google/resolve", type: "get", allowCors: true, ips: ["8.8.8.8", "8.8.4.4"]
 }, {
     name: "Mullvad", url: "https://dns.mullvad.net/dns-query", ips: ["194.242.2.2", "194.242.2.2"]
-}, 
-   {
+}, {
     name: "Mullvad Base", url: "https://base.dns.mullvad.net/dns-query", ips: ["194.242.2.4", "194.242.2.4"]
-},
+}, {
     name: "NextDNS", url: "https://dns.nextdns.io", type: "get", ips: ["45.90.28.0", "45.90.30.0"]
 }, {
     name: "OpenBLD", url: "https://ada.openbld.net/dns-query", ips: ["146.112.41.2", "146.112.41.102"]


### PR DESCRIPTION
This error is deployed and the site is no longer working.
There was a missing curly brace that rendered the whole site useless. I noticed this when I tried to run the site.
Fixed in this pull request