### PR TITLE
Improve DNS test configuration modals and remove unused theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,314 +1,420 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description"
-          content="Experience the only web-based DNS Speed Test. Find the fastest DNS server for your location without any installations or downloads.">
-    <meta name="keywords" content="DNS Speed Test, DNS Server, Fast DNS, Internet Speed, DNS Performance">
-    <meta name="author" content="@SilviuStroe">
-    <title>Fastest DNS Speed Test - Find Optimal DNS Server | No Install</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-        button:disabled {
-            opacity: 0.5;
-            cursor: not-allowed;
-        }
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description"
+        content="Experience the only web-based DNS Speed Test. Find the fastest DNS server for your location without any installations or downloads." />
+  <meta name="keywords" content="DNS Speed Test, DNS Server, Fast DNS, Internet Speed, DNS Performance" />
+  <meta name="author" content="@SilviuStroe" />
 
-        .spinner {
-            display: inline-block;
-            position: relative;
-            width: 70px;
-            height: 70px;
-            vertical-align: middle;
-        }
+  <title>Fastest DNS Speed Test - Find Optimal DNS Server | No Install</title>
 
-        .dot {
-            position: absolute;
-            width: 10px;
-            height: 10px;
-            background-color: #3498db;
-            border-radius: 50%;
-            animation: dot-blink 2s linear infinite;
-        }
+  <!-- Perf: warm up connections -->
+  <link rel="preconnect" href="https://cdn.tailwindcss.com" crossorigin>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
 
-        .dot-1 {
-            left: 30%;
-            top: 50%;
-            animation-delay: -1.6s;
-        }
+  <!-- Tailwind -->
+  <script src="https://cdn.tailwindcss.com"></script>
 
-        .dot-2 {
-            left: 50%;
-            top: 30%;
-            animation-delay: -0.8s;
-        }
+  <style>
+    button:disabled { opacity: 0.55; cursor: not-allowed; }
 
-        .dot-3 {
-            left: 70%;
-            top: 50%;
-            animation-delay: 0s;
-        }
+    /* Loading dots */
+    .spinner { display:inline-block; position:relative; width:70px; height:22px; vertical-align:middle; }
+    .dot { position:absolute; width:10px; height:10px; background:#38bdf8; border-radius:50%; animation:dot-blink 1.2s linear infinite; }
+    .dot-1 { left:10px; top:6px; animation-delay:-0.8s; }
+    .dot-2 { left:30px; top:6px; animation-delay:-0.4s; }
+    .dot-3 { left:50px; top:6px; animation-delay:0s; }
+    @keyframes dot-blink { 0%,100%{opacity:.2} 50%{opacity:1} }
 
-        @keyframes dot-blink {
-            0%, 100% {
-                opacity: 0;
-            }
-            50% {
-                opacity: 1;
-            }
-        }
-    </style>
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="favicon/site.webmanifest">
-    <script type="application/ld+json">
-        {
-            "@context": "http://schema.org",
-            "@type": "SoftwareApplication",
-            "name": "DNS Speed Test",
-            "description": "Discover the fastest DNS server for your specific location with our advanced DNS Speed Test tool. Enhance your browsing speed and internet reliability effortlessly.",
-            "url": "https://dnsspeedtest.online/",
-            "author": {
-                "@type": "Person",
-                "name": "@SilviuStroe"
-            },
-            "applicationCategory": "WebApplication",
-            "operatingSystem": "All",
-            "offers": {
-                "@type": "Offer",
-                "price": "0",
-                "priceCurrency": "USD"
-            }
-        }
-    </script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-zoom/2.0.1/chartjs-plugin-zoom.min.js"></script>
+    /* Modal polish */
+    .modal-content { max-height: calc(100vh - 3rem); }
+
+    /* Better focus visibility */
+    :focus-visible { outline: 3px solid rgba(59,130,246,.6); outline-offset: 2px; }
+  </style>
+
+  <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png" />
+  <link rel="manifest" href="favicon/site.webmanifest" />
+
+  <script type="application/ld+json">
+    {
+      "@context": "http://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "DNS Speed Test",
+      "description": "Discover the fastest DNS server for your specific location with our advanced DNS Speed Test tool. Enhance your browsing speed and internet reliability effortlessly.",
+      "url": "https://dnsspeedtest.online/",
+      "author": { "@type": "Person", "name": "@SilviuStroe" },
+      "applicationCategory": "WebApplication",
+      "operatingSystem": "All",
+      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+    }
+  </script>
+
+  <!-- Charts (defer for perf) -->
+  <script defer src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-zoom/2.0.1/chartjs-plugin-zoom.min.js"></script>
 </head>
-<body class="pt-20 font-sans text-center p-5 bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200">
-<div class="flex justify-center items-center">
-    <div class="w-full md:w-2/3 mx-auto">
-        <h1 id="cta" class="text-4xl text-blue-500 font-bold mb-2 text-center dark:text-blue-300">
-            DNS Speed Test Benchmark - Find the Fastest DNS Server for Your Location
-        </h1>
-    </div>
-</div>
-<p class="text-lg mx-auto mb-5 leading-relaxed max-w-xl dark:text-gray-300">Optimize your internet experience by finding
-    the fastest DNS server for your location. Just click the button below to start the test.</p>
-<button id="checkButton"
-        class="bg-green-500 text-white py-3 px-6 text-lg rounded-lg shadow-lg transform transition duration-300 ease-in-out hover:scale-105 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-700 focus:ring-opacity-50 mb-5 dark:bg-green-600 dark:hover:bg-green-800">
-    Check DNS Speed
-</button>
-<div class="absolute top-5 right-5">
-    <div class="group relative inline-block">
-        <button id="editButton"
-                class="bg-white text-2xl text-white bg-transparent border-none rounded-full w-10 h-10 flex justify-center items-center shadow-lg">
-            🛠️
-        </button>
-        <span class="pointer-events-none absolute top-full right-0 transform translate-y-2 w-max bg-black text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity">
+
+<body class="min-h-screen bg-slate-50 text-slate-800 dark:bg-slate-950 dark:text-slate-100 antialiased">
+  <!-- Background accents -->
+  <div aria-hidden="true" class="pointer-events-none fixed inset-0">
+    <div class="absolute -top-24 left-1/2 h-72 w-[40rem] -translate-x-1/2 rounded-full bg-sky-300/25 blur-3xl dark:bg-sky-500/10"></div>
+    <div class="absolute top-64 right-[-10rem] h-72 w-[30rem] rounded-full bg-emerald-300/20 blur-3xl dark:bg-emerald-500/10"></div>
+  </div>
+
+  <!-- Top bar -->
+  <header class="sticky top-0 z-40 backdrop-blur bg-white/70 dark:bg-slate-950/60 border-b border-slate-200/70 dark:border-slate-800/70">
+    <div class="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between gap-3">
+      <div class="flex items-center gap-3">
+        <div class="h-9 w-9 rounded-xl bg-gradient-to-br from-sky-500 to-emerald-500 shadow-sm"></div>
+        <div class="leading-tight">
+          <p class="text-sm font-semibold">DNS Speed Test</p>
+          <p class="text-xs text-slate-500 dark:text-slate-400">Browser-based DoH benchmark</p>
+        </div>
+      </div>
+
+      <!-- Tools -->
+      <div class="flex items-center gap-2">
+        <div class="group relative">
+          <button id="editButton"
+                  type="button"
+                  class="h-10 w-10 rounded-full bg-white/90 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 shadow-sm hover:shadow transition flex items-center justify-center"
+                  aria-label="Edit hosts list"
+                  title="Edit hosts list">
+            <span class="text-xl">🛠️</span>
+          </button>
+          <span class="pointer-events-none absolute right-0 top-full mt-2 w-max rounded-md bg-slate-900 text-white text-xs px-2 py-1 opacity-0 group-hover:opacity-100 transition">
             Edit hosts list
-        </span>
-    </div>
-    <div class="group relative inline-block">
-        <button id="editDoHButton"
-                class="bg-white text-2xl text-white bg-transparent border-none rounded-full w-10 h-10 flex justify-center items-center shadow-lg">
-            🛡️
-        </button>
-        <span class="pointer-events-none absolute top-full right-0 transform translate-y-2 w-max bg-black text-white text-xs rounded py-1 px-2 opacity-0 group-hover:opacity-100 transition-opacity">
+          </span>
+        </div>
+
+        <div class="group relative">
+          <button id="editDoHButton"
+                  type="button"
+                  class="h-10 w-10 rounded-full bg-white/90 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 shadow-sm hover:shadow transition flex items-center justify-center"
+                  aria-label="Add DoH servers"
+                  title="Add DoH servers">
+            <span class="text-xl">🛡️</span>
+          </button>
+          <span class="pointer-events-none absolute right-0 top-full mt-2 w-max rounded-md bg-slate-900 text-white text-xs px-2 py-1 opacity-0 group-hover:opacity-100 transition">
             Add DoH servers
+          </span>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main class="relative mx-auto max-w-6xl px-4 py-10">
+    <!-- Hero -->
+    <section class="text-center">
+      <h1 id="cta" class="text-3xl sm:text-4xl font-extrabold tracking-tight">
+        <span class="bg-gradient-to-r from-sky-600 to-emerald-600 bg-clip-text text-transparent">
+          DNS Speed Test Benchmark
         </span>
-    </div>
-</div>
-<div id="loadingMessage" class="hidden"></div>
-<!-- Modal for editing DNS test hosts -->
-<div id="websiteModal" class="hidden fixed z-50 inset-0 flex items-center justify-center bg-black bg-opacity-60">
-    <div class="modal-content relative bg-white pt-4 pb-2 px-4 rounded-lg shadow-xl w-full sm:w-11/12 md:w-1/2 mx-auto my-2 sm:my-4 overflow-hidden dark:bg-gray-700 dark:text-white">
-        <span class="close absolute top-2 right-2 text-3xl font-bold text-gray-500 hover:text-black cursor-pointer p-1 dark:text-gray-200 dark:hover:text-white">×</span>
-        <h2 class="text-2xl sm:text-3xl mb-2 sm:mb-4 font-semibold dark:text-gray-200">Edit DNS Test Hosts</h2>
-        <p class="mb-2 sm:mb-4 text-base sm:text-lg leading-relaxed dark:text-gray-300">
-            Add or remove hostnames to tailor DNS server testing. Incorporate websites you frequently visit or popular
-            services to refine the accuracy of your DNS speed test.
-        </p>
-        <!-- Scrollable List Container -->
-        <div class="overflow-auto max-h-[50vh] sm:max-h-[60vh]"> <!-- Adjust max height as needed -->
-            <ul id="websiteList" class="list-none p-0">
-                <!-- Dynamic list items will be added here -->
-            </ul>
-        </div>
-        <div class="flex mt-2 sm:mt-4 justify-center">
-            <input type="text" id="newWebsite"
-                   class="py-2 mr-2 px-4 w-3/4 border-2 border-gray-400 rounded focus:border-blue-500 focus:outline-none transition duration-200 ease-in-out placeholder-gray-600 dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-400"
-                   placeholder="Add new hostname...">
-            <button id="addHostname"
-                    class="py-2 px-6 bg-green-500 text-white rounded hover:bg-green-600 text-lg dark:bg-green-700 dark:hover:bg-green-900">
-                Add
-            </button>
-        </div>
-    </div>
-</div>
-<div id="dnsResults" aria-live="polite" class="mt-5 overflow-x-auto">
-    <table id="resultsTable" class="w-full border-collapse table-fixed">
-        <thead>
-        <tr>
-            <th class="w-1/3 py-2 px-4 text-left border-b border-gray-300 bg-blue-200 text-gray-700 cursor-pointer dark:bg-gray-800 dark:text-gray-200">
-                DNS Server
-            </th>
-            <th onclick="sortTable(1)"
-                class="py-2 px-4 text-center border-b border-gray-300 bg-blue-200 text-gray-700 cursor-pointer dark:bg-gray-800 dark:text-gray-200">
-                Min (ms) &#x2195;
-            </th>
-            <th onclick="sortTable(2)"
-                class="py-2 px-4 text-center border-b border-gray-300 bg-blue-200 text-gray-700 cursor-pointer dark:bg-gray-800 dark:text-gray-200">
-                Median (ms) &#x2195;
-            </th>
-            <th onclick="sortTable(3)"
-                class="py-2 px-4 text-center border-b border-gray-300 bg-blue-200 text-gray-700 cursor-pointer dark:bg-gray-800 dark:text-gray-200">
-                Average (ms) &#x2195;
-            </th>
-            <th onclick="sortTable(4)"
-                class="py-2 px-4 text-center border-b border-gray-300 bg-blue-200 text-gray-700 cursor-pointer dark:bg-gray-800 dark:text-gray-200">
-                Max (ms) &#x2195;
-            </th>
-        </tr>
-        </thead>
-        <tbody class="text-gray-800 dark:text-gray-200">
-        <!-- Table rows will be dynamically added here -->
-        </tbody>
-    </table>
-</div>
-<!-- Modal for adding new DoH servers -->
-<div id="dohModal" class="hidden fixed z-50 inset-0 flex items-center justify-center bg-black bg-opacity-60">
-    <div class="modal-content relative bg-white pt-4 pb-2 px-4 rounded-lg shadow-xl w-full sm:w-11/12 md:w-1/2 mx-auto my-2 sm:my-4 overflow-hidden dark:bg-gray-700 dark:text-white">
-        <span class="close absolute top-2 right-2 text-3xl font-bold text-gray-500 hover:text-black cursor-pointer p-1 dark:text-gray-200 dark:hover:text-white">×</span>
-        <h2 class="text-2xl sm:text-3xl mb-2 sm:mb-4 font-semibold dark:text-gray-200">Add Custom DoH Servers</h2>
-        <p class="mb-2 sm:mb-4 text-base sm:text-lg leading-relaxed dark:text-gray-300">
-            Enhance your DNS speed test by adding custom DNS-over-HTTPS (DoH) servers. Include popular DoH providers or
-            your preferred services to expand the range of tested DNS servers.
-        </p>
-        <!-- Scrollable List Container -->
-        <div class="overflow-auto max-h-[50vh] sm:max-h-[60vh]"> <!-- Adjust max height as needed -->
-            <ul id="dohList" class="list-none p-0">
-                <!-- Dynamic list items will be added here -->
-            </ul>
-        </div>
-        <div class="flex mt-2 sm:mt-4 justify-center">
-            <input type="url" id="newDoH"
-                   class="py-2 mr-2 px-4 w-3/4 border-2 border-gray-400 rounded focus:border-blue-500 focus:outline-none transition duration-200 ease-in-out placeholder-gray-600 dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-400"
-                   placeholder="Add new DoH server in the Name, URL format...">
-            <button id="addDoH"
-                    class="py-2 px-6 bg-green-500 text-white rounded hover:bg-green-600 text-lg dark:bg-green-700 dark:hover:bg-green-900">
-                Add
-            </button>
-        </div>
-    </div>
-</div>
-<div id="chartContainer" class="w-full md:w-4/5 mx-auto mt-5 px-2 md:px-0 hidden">
-    <div class="chart-container" style="position: relative; height: 400px; width: 100%;">
-        <canvas id="dnsChart"></canvas>
-    </div>
-    <div class="text-center mt-3">
-        <p class="text-sm text-gray-600 dark:text-gray-400 hidden md:block">DNS Speed Comparison (Fastest → Slowest)</p>
-    </div>
-</div>
-<div id="disclaimer"
-     class="mt-10 px-5 py-4 bg-white border border-gray-300 rounded text-left max-w-7xl mx-auto leading-relaxed space-y-4 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-200">
-    <h2 class="text-2xl text-blue-500 mb-4 dark:text-blue-400">Disclaimer</h2>
+        <span class="block mt-2 text-slate-900 dark:text-white font-bold">
+          Find the fastest DNS server for your location
+        </span>
+      </h1>
 
-    <p>
+      <p class="mx-auto mt-4 max-w-2xl text-base sm:text-lg leading-relaxed text-slate-600 dark:text-slate-300">
+        Run a live DNS-over-HTTPS benchmark from your current network. No installs, no downloads—just click and compare.
+      </p>
+
+      <div class="mt-6 flex items-center justify-center gap-3">
+        <button id="checkButton"
+                class="inline-flex items-center justify-center gap-3 rounded-xl bg-emerald-600 px-6 py-3 text-base sm:text-lg font-semibold text-white shadow-lg shadow-emerald-600/20 hover:bg-emerald-700 active:scale-[0.99] transition"
+                type="button">
+          <span>Check DNS Speed</span>
+          <span aria-hidden="true">→</span>
+        </button>
+      </div>
+
+      <!-- Loading / status -->
+      <div class="mt-6">
+        <div id="loadingMessage" class="hidden" aria-live="polite">
+          <div class="inline-flex items-center gap-3 rounded-2xl bg-white/80 dark:bg-slate-900/70 border border-slate-200 dark:border-slate-800 px-4 py-3 shadow-sm">
+            <div class="spinner" aria-hidden="true">
+              <span class="dot dot-1"></span>
+              <span class="dot dot-2"></span>
+              <span class="dot dot-3"></span>
+            </div>
+            <div class="text-left">
+              <p class="text-sm font-semibold">Testing DNS servers…</p>
+              <p class="text-xs text-slate-500 dark:text-slate-400">This may take a few seconds depending on network conditions.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Results -->
+    <section class="mt-10">
+      <div class="rounded-2xl bg-white/80 dark:bg-slate-900/70 border border-slate-200 dark:border-slate-800 shadow-sm overflow-hidden">
+        <div class="px-4 sm:px-6 py-4 border-b border-slate-200 dark:border-slate-800 flex items-center justify-between">
+          <h2 class="text-lg font-semibold">Results</h2>
+          <p class="text-xs text-slate-500 dark:text-slate-400">Click headers to sort</p>
+        </div>
+
+        <div id="dnsResults" aria-live="polite" class="overflow-x-auto">
+          <table id="resultsTable" class="min-w-full table-fixed">
+            <thead class="sticky top-0 z-10">
+              <tr class="bg-slate-50 dark:bg-slate-950/60">
+                <th class="w-1/3 px-4 sm:px-6 py-3 text-left text-sm font-semibold text-slate-700 dark:text-slate-200 border-b border-slate-200 dark:border-slate-800">
+                  DNS Server
+                </th>
+                <th onclick="sortTable(1)"
+                    class="px-4 py-3 text-center text-sm font-semibold text-slate-700 dark:text-slate-200 border-b border-slate-200 dark:border-slate-800 cursor-pointer select-none">
+                  Min (ms) ↕
+                </th>
+                <th onclick="sortTable(2)"
+                    class="px-4 py-3 text-center text-sm font-semibold text-slate-700 dark:text-slate-200 border-b border-slate-200 dark:border-slate-800 cursor-pointer select-none">
+                  Median (ms) ↕
+                </th>
+                <th onclick="sortTable(3)"
+                    class="px-4 py-3 text-center text-sm font-semibold text-slate-700 dark:text-slate-200 border-b border-slate-200 dark:border-slate-800 cursor-pointer select-none">
+                  Average (ms) ↕
+                </th>
+                <th onclick="sortTable(4)"
+                    class="px-4 py-3 text-center text-sm font-semibold text-slate-700 dark:text-slate-200 border-b border-slate-200 dark:border-slate-800 cursor-pointer select-none">
+                  Max (ms) ↕
+                </th>
+              </tr>
+            </thead>
+
+            <tbody class="text-sm text-slate-800 dark:text-slate-200">
+              <!-- Your script.js will inject rows here -->
+              <!-- Suggested row classes from JS:
+                   "border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50/70 dark:hover:bg-slate-800/30 transition" -->
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <!-- Chart -->
+    <section id="chartContainer" class="mt-8 hidden">
+      <div class="rounded-2xl bg-white/80 dark:bg-slate-900/70 border border-slate-200 dark:border-slate-800 shadow-sm overflow-hidden">
+        <div class="px-4 sm:px-6 py-4 border-b border-slate-200 dark:border-slate-800 flex items-center justify-between">
+          <h2 class="text-lg font-semibold">DNS Speed Comparison</h2>
+          <p class="text-xs text-slate-500 dark:text-slate-400 hidden sm:block">Fastest → Slowest</p>
+        </div>
+
+        <div class="p-3 sm:p-6">
+          <div class="relative h-[380px] w-full chart-container">
+            <canvas id="dnsChart"></canvas>
+          </div>
+          <p class="mt-3 text-center text-xs text-slate-500 dark:text-slate-400 sm:hidden">
+            Fastest → Slowest
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Disclaimer -->
+    <section id="disclaimer"
+             class="mt-10 rounded-2xl bg-white/80 dark:bg-slate-900/70 border border-slate-200 dark:border-slate-800 shadow-sm p-5 sm:p-7 text-left space-y-4">
+      <h2 class="text-2xl font-bold bg-gradient-to-r from-sky-600 to-emerald-600 bg-clip-text text-transparent">
+        Disclaimer
+      </h2>
+
+      <p>
         This <strong>DNS Speed Test tool</strong> runs entirely in your browser, sending live DNS-over-HTTPS (DoH)
-        queries from your local environment. No server-side code is involved, and no personal data is collected. By
-        measuring directly from your current network, the tool aims to provide <strong>accurate, real-world
-        results</strong>.
-    </p>
+        queries from your local environment. No server-side code is involved, and no personal data is collected.
+      </p>
 
-    <p>
+      <p>
         <strong>Warm-Up Phase:</strong> Before timing each DNS server, the script primes connections and caches to
-        minimize the overhead of TCP/TLS handshakes. This warm-up step helps ensure consistent, ready-to-go conditions
-        when actual measurements begin. While it adds a small initial delay, it more fairly represents typical DoH
-        performance once connections are established.
-    </p>
+        minimize overhead from TCP/TLS handshakes.
+      </p>
 
-    <p>
-        <strong>Time Measurement & Browser Overhead:</strong> We use the browser’s <code>fetch</code> and
-        <code>performance.now()</code> APIs to measure full DoH round-trip times. Because this includes HTTP/TLS
-        overhead, results may be higher than raw DNS queries performed by other tools. Depending on server capabilities,
-        our script may use <code>GET</code> or <code>POST</code>, CORS or <code>no-cors</code> mode. Some endpoints
-        require a preflight request, which can slightly affect timings.
-    </p>
+      <p>
+        <strong>Time Measurement & Browser Overhead:</strong> We use <code>fetch</code> and
+        <code>performance.now()</code> to measure DoH round-trip times. Results may be higher than raw DNS tools due to
+        HTTP/TLS overhead and browser behavior.
+      </p>
 
-    <p>
+      <p>
         <strong>Timeouts & Unavailable Results:</strong> Each query times out after 5 seconds. If a server does not
-        respond in that window, it appears as <em>Unavailable</em>. This ensures the test continues promptly even when
-        certain DNS endpoints are slow or unreachable.
-    </p>
+        respond in that window, it appears as <em>Unavailable</em>.
+      </p>
 
-    <p>
+      <p>
         <strong>Influence of Local Conditions:</strong> Network latency, bandwidth, and browser load can cause
-        variability. <strong>We recommend running multiple tests</strong> at different times or under different network
-        conditions to get a broader picture. The tool’s output is best used as a <strong>relative comparison</strong>
-        among DNS servers under your specific circumstances rather than an absolute global measure.
-    </p>
+        variability. Run multiple tests at different times for a broader picture.
+      </p>
 
-    <p>
-        While <strong>we strive for accuracy</strong> by testing each DNS server with the same set of hostnames (and
-        reusing warm connections), results are still <strong>indicative</strong>. Use them as a guide when deciding
-        which DNS server offers the best performance for your location and environment.
-    </p>
-</div>
-<footer class="bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 border-t border-gray-200 dark:border-gray-700 mt-16">
-    <div class="container mx-auto px-4 py-6">
-        <!-- Support Section -->
-        <div class="text-center mb-6">
-            <p class="text-gray-600 dark:text-gray-400 mb-4">
-                💚 Help keep this tool free and updated
-            </p>
+      <p>
+        Results are <strong>relative comparisons</strong> under your current conditions and should be used as guidance
+        when choosing a DNS provider.
+      </p>
+    </section>
+  </main>
 
-            <div class="flex flex-col sm:flex-row gap-3 justify-center items-center">
-                <a href="https://www.buymeacoffee.com/silviu"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="inline-flex items-center gap-2 bg-yellow-400 hover:bg-yellow-500 text-black font-medium px-4 py-2 rounded-full transition-all duration-200 transform hover:scale-105 shadow-md hover:shadow-lg text-sm">
-                    <span>☕</span>
-                    <span>Buy me a coffee</span>
-                </a>
+  <!-- Footer -->
+  <footer class="border-t border-slate-200 dark:border-slate-800 bg-white/70 dark:bg-slate-950/60">
+    <div class="mx-auto max-w-6xl px-4 py-8">
+      <div class="text-center space-y-4">
+        <p class="text-sm text-slate-600 dark:text-slate-400">💚 Help keep this tool free and updated</p>
 
-                <span class="text-gray-400">or</span>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center items-center">
+          <a href="https://www.buymeacoffee.com/silviu"
+             target="_blank"
+             rel="noopener noreferrer"
+             class="inline-flex items-center gap-2 rounded-full bg-yellow-400 px-4 py-2 text-sm font-semibold text-black shadow-sm hover:bg-yellow-500 transition">
+            <span>☕</span><span>Buy me a coffee</span>
+          </a>
 
-                <a href="https://www.linkedin.com/in/silviustroe/"
-                   title="Hire Silviu Stroe"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="inline-flex items-center gap-2 text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 font-medium transition-colors duration-200 text-sm">
-                    <span class="text-base">👨🏻‍💻</span>
-                    <span>Hire me</span>
-                </a>
-            </div>
+          <span class="text-slate-400 text-sm">or</span>
+
+          <a href="https://www.linkedin.com/in/silviustroe/"
+             target="_blank"
+             rel="noopener noreferrer"
+             class="inline-flex items-center gap-2 text-sm font-semibold text-sky-700 hover:text-sky-800 dark:text-sky-400 dark:hover:text-sky-300 transition">
+            <span class="text-base">👨🏻‍💻</span><span>Hire me</span>
+          </a>
         </div>
 
-        <!-- GitHub & Copyright -->
-        <div class="border-t border-gray-200 dark:border-gray-700 pt-4 flex flex-col sm:flex-row justify-between items-center gap-3">
-            <p class="text-xs text-gray-500 dark:text-gray-400">
-                © 2024-2025 <span class="font-medium">DNSSpeedTest.online</span> • Made with ❤️ for the community by
-                <a title="Brainic - AI Solutions & Software Development" href="https://brainic.io" target="_blank"
-                   rel="noopener noreferrer"
-                   class="inline-flex items-center gap-2 text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 font-medium transition-colors duration-200 text-sm">Brainic</a>
-            </p>
+        <div class="pt-6 border-t border-slate-200 dark:border-slate-800 flex flex-col sm:flex-row justify-between items-center gap-3">
+          <p class="text-xs text-slate-500 dark:text-slate-400">
+            © 2024-2025 <span class="font-medium">DNSSpeedTest.online</span> • Made with ❤️ by
+            <a href="https://brainic.io" target="_blank" rel="noopener noreferrer"
+               class="text-sky-700 hover:text-sky-800 dark:text-sky-400 dark:hover:text-sky-300 font-semibold">
+              Brainic
+            </a>
+          </p>
 
-            <div class="flex items-center gap-3">
-                <span class="text-xs text-gray-500 dark:text-gray-400">⭐ Star on GitHub:</span>
-                <a rel="noopener noreferrer"
-                   class="github-button"
-                   href="https://github.com/BrainicHQ/DoHSpeedTest"
-                   data-show-count="true"
-                   aria-label="Star BrainicHQ/DoHSpeedTest on GitHub">
-                    Star
-                </a>
-            </div>
+          <div class="flex items-center gap-3">
+            <span class="text-xs text-slate-500 dark:text-slate-400">⭐ Star on GitHub:</span>
+            <a rel="noopener noreferrer"
+               class="github-button"
+               href="https://github.com/BrainicHQ/DoHSpeedTest"
+               data-show-count="true"
+               aria-label="Star BrainicHQ/DoHSpeedTest on GitHub">
+              Star
+            </a>
+          </div>
         </div>
+      </div>
     </div>
-</footer>
-<script async defer src="https://buttons.github.io/buttons.js"></script>
-<script src="script.js"></script>
+  </footer>
+
+  <script async defer src="https://buttons.github.io/buttons.js"></script>
+
+  <!-- Your logic (defer to avoid blocking render) -->
+  <script defer src="script.js"></script>
+
+  <!-- Modals (unchanged IDs so your JS still works) -->
+  <!-- Modal for editing DNS test hosts -->
+  <div id="websiteModal" class="hidden fixed z-50 inset-0 flex items-center justify-center bg-black/60 p-3">
+    <div class="modal-content relative w-full sm:w-11/12 md:w-1/2 rounded-2xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 shadow-xl overflow-hidden">
+      <button class="close absolute top-3 right-3 h-10 w-10 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition flex items-center justify-center text-2xl text-slate-500 dark:text-slate-300"
+              aria-label="Close modal">×</button>
+
+      <div class="p-5 sm:p-6">
+        <h2 class="text-2xl sm:text-3xl font-bold">Edit DNS Test Hosts</h2>
+        <p class="mt-2 text-sm sm:text-base text-slate-600 dark:text-slate-300">
+          Add or remove hostnames to tailor DNS server testing.
+        </p>
+
+        <div class="mt-4 flex flex-col sm:flex-row items-start sm:items-center gap-3">
+          <span id="hostCountBadge"
+                class="inline-flex items-center gap-2 rounded-full bg-slate-100 dark:bg-slate-800 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-200">
+            0 hostnames configured
+          </span>
+          <button id="resetHostnames"
+                  type="button"
+                  class="inline-flex items-center gap-2 rounded-full border border-slate-200 dark:border-slate-700 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition">
+            Restore recommended list
+          </button>
+        </div>
+        <p id="websiteFeedback" class="mt-2 text-sm text-slate-500 dark:text-slate-400"></p>
+
+        <div class="mt-4 overflow-auto max-h-[55vh] rounded-xl border border-slate-200 dark:border-slate-800">
+          <ul id="websiteList" class="p-2 sm:p-3 space-y-2"></ul>
+        </div>
+
+        <div class="mt-4 flex flex-col sm:flex-row gap-2">
+          <input type="text" id="newWebsite"
+                 class="flex-1 rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-4 py-2 text-sm sm:text-base focus:border-sky-500 focus:outline-none"
+                 placeholder="Add one or more hostnames (comma or newline separated)..." />
+          <button id="addHostname"
+                  class="rounded-xl bg-emerald-600 px-5 py-2 text-white font-semibold hover:bg-emerald-700 transition">
+            Add
+          </button>
+        </div>
+        <p class="mt-2 text-xs text-slate-500 dark:text-slate-400">
+          Tip: paste URLs or hostnames separated by commas or new lines. We'll extract valid hosts automatically.
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal for adding new DoH servers -->
+  <div id="dohModal" class="hidden fixed z-50 inset-0 flex items-center justify-center bg-black/60 p-3">
+    <div class="modal-content relative w-full sm:w-11/12 md:w-1/2 rounded-2xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 shadow-xl overflow-hidden">
+      <button class="close absolute top-3 right-3 h-10 w-10 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition flex items-center justify-center text-2xl text-slate-500 dark:text-slate-300"
+              aria-label="Close modal">×</button>
+
+      <div class="p-5 sm:p-6">
+        <h2 class="text-2xl sm:text-3xl font-bold">Add Custom DoH Servers</h2>
+        <p class="mt-2 text-sm sm:text-base text-slate-600 dark:text-slate-300">
+          Add DoH endpoints to expand the range of tested DNS servers.
+        </p>
+
+        <div class="mt-4 flex flex-col sm:flex-row items-start sm:items-center gap-3">
+          <span id="dohCountBadge"
+                class="inline-flex items-center gap-2 rounded-full bg-slate-100 dark:bg-slate-800 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-200">
+            0 DoH servers configured
+          </span>
+          <button id="resetDoHButton"
+                  type="button"
+                  class="inline-flex items-center gap-2 rounded-full border border-slate-200 dark:border-slate-700 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition">
+            Restore curated list
+          </button>
+        </div>
+        <p id="dohFeedback" class="mt-2 text-sm text-slate-500 dark:text-slate-400"></p>
+
+        <div class="mt-4 overflow-auto max-h-[55vh] rounded-xl border border-slate-200 dark:border-slate-800">
+          <ul id="dohList" class="p-2 sm:p-3 space-y-2"></ul>
+        </div>
+
+        <div class="mt-4 grid gap-3 sm:grid-cols-2">
+          <label class="text-sm text-slate-600 dark:text-slate-300 flex flex-col gap-1">
+            Server name
+            <input type="text" id="newDoHName"
+                   class="rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-4 py-2 text-sm focus:border-sky-500 focus:outline-none"
+                   placeholder="e.g., MyCorp DNS" />
+          </label>
+          <label class="text-sm text-slate-600 dark:text-slate-300 flex flex-col gap-1">
+            DoH endpoint URL
+            <input type="url" id="newDoHUrl"
+                   class="rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-4 py-2 text-sm focus:border-sky-500 focus:outline-none"
+                   placeholder="https://example.com/dns-query" />
+          </label>
+          <label class="text-sm text-slate-600 dark:text-slate-300 flex flex-col gap-1 sm:col-span-2">
+            Known IPs (optional, comma separated)
+            <input type="text" id="newDoHIps"
+                   class="rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-4 py-2 text-sm focus:border-sky-500 focus:outline-none"
+                   placeholder="1.1.1.1, 1.0.0.1" />
+          </label>
+        </div>
+
+        <div class="mt-4 flex flex-col sm:flex-row items-center gap-2">
+          <button id="addDoH"
+                  class="w-full sm:w-auto rounded-xl bg-emerald-600 px-5 py-2 text-white font-semibold hover:bg-emerald-700 transition">
+            Check & add server
+          </button>
+          <p class="text-xs text-slate-500 dark:text-slate-400">
+            We'll auto-detect GET/POST and CORS support before saving the server.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -19,11 +19,25 @@
  */
 const checkButton = document.getElementById('checkButton');
 const editButton = document.getElementById('editButton');
-const topWebsites = ['google.com', 'youtube.com', 'facebook.com', 'instagram.com', 'chatgpt.com', 'x.com', 'whatsapp.com', 'reddit.com', 'wikipedia.org', 'amazon.com', 'tiktok.com', 'pinterest.com'];
+const hostFeedback = document.getElementById('websiteFeedback');
+const hostCountBadge = document.getElementById('hostCountBadge');
+const resetHostnamesButton = document.getElementById('resetHostnames');
+const dohFeedback = document.getElementById('dohFeedback');
+const dohCountBadge = document.getElementById('dohCountBadge');
+const resetDoHButton = document.getElementById('resetDoHButton');
+const newDoHNameInput = document.getElementById('newDoHName');
+const newDoHUrlInput = document.getElementById('newDoHUrl');
+const newDoHIpsInput = document.getElementById('newDoHIps');
+const DEFAULT_TOP_WEBSITES = ['google.com', 'youtube.com', 'facebook.com', 'instagram.com', 'chatgpt.com', 'x.com', 'whatsapp.com', 'reddit.com', 'wikipedia.org', 'amazon.com', 'tiktok.com', 'pinterest.com'];
+const STORAGE_KEYS = {
+    hostnames: 'dohSpeedTest.hostnames',
+    servers: 'dohSpeedTest.dnsServers'
+};
+let topWebsites = loadStoredHostnames();
 // Penalize failed/timeout requests so they don't skew averages in favor of unstable servers
 const TIMEOUT_PENALTY_MS = 5000;
 // Global variable to store chart instance
-const dnsServers = [{
+const DEFAULT_DNS_SERVERS = [{
     name: "AdGuard", url: "https://dns.adguard-dns.com/dns-query", ips: ["94.140.14.14", "94.140.15.15"]
 }, {
     name: "AliDNS", url: "https://dns.alidns.com/dns-query", ips: ["223.5.5.5", "223.6.6.6"]
@@ -113,6 +127,135 @@ const dnsServers = [{
     }
 ];
 
+let dnsServers = loadStoredDnsServers();
+const modalFeedbackElements = {
+    hosts: hostFeedback,
+    doh: dohFeedback
+};
+const MODAL_FEEDBACK_BASE = 'mt-2 text-sm';
+const MODAL_FEEDBACK_STYLES = {
+    info: 'text-slate-500 dark:text-slate-400',
+    success: 'text-emerald-600 dark:text-emerald-300',
+    error: 'text-red-600 dark:text-red-300'
+};
+
+function syncRunButtonState() {
+    checkButton.disabled = topWebsites.length === 0 || dnsServers.length === 0;
+}
+syncRunButtonState();
+updateHostStats();
+updateDoHStats();
+clearModalFeedback('hosts');
+clearModalFeedback('doh');
+
+function loadStoredHostnames() {
+    try {
+        const stored = localStorage.getItem(STORAGE_KEYS.hostnames);
+        if (stored) {
+            const parsed = JSON.parse(stored);
+            if (Array.isArray(parsed) && parsed.every(item => typeof item === 'string')) {
+                return parsed;
+            }
+        }
+    } catch (error) {
+        console.warn('Unable to load stored hostnames, falling back to defaults.', error);
+    }
+    return [...DEFAULT_TOP_WEBSITES];
+}
+
+function loadStoredDnsServers() {
+    try {
+        const stored = localStorage.getItem(STORAGE_KEYS.servers);
+        if (stored) {
+            const parsed = JSON.parse(stored);
+            if (Array.isArray(parsed)) {
+                return parsed.map(cloneServer);
+            }
+        }
+    } catch (error) {
+        console.warn('Unable to load stored DoH servers, falling back to defaults.', error);
+    }
+    return DEFAULT_DNS_SERVERS.map(cloneServer);
+}
+
+function persistHostnames() {
+    try {
+        localStorage.setItem(STORAGE_KEYS.hostnames, JSON.stringify(topWebsites));
+    } catch (error) {
+        console.warn('Unable to persist hostnames', error);
+    }
+}
+
+function persistDnsServers() {
+    try {
+        localStorage.setItem(STORAGE_KEYS.servers, JSON.stringify(dnsServers));
+    } catch (error) {
+        console.warn('Unable to persist DoH servers', error);
+    }
+}
+
+function cloneServer(server) {
+    return {
+        ...server,
+        ips: Array.isArray(server.ips) ? [...server.ips] : []
+    };
+}
+
+function showModalFeedback(target, type, message) {
+    const element = modalFeedbackElements[target];
+    if (!element) return;
+    const feedbackType = MODAL_FEEDBACK_STYLES[type] || MODAL_FEEDBACK_STYLES.info;
+    element.className = `${MODAL_FEEDBACK_BASE} ${feedbackType}`;
+    element.textContent = message;
+    element.classList.remove('hidden');
+}
+
+function clearModalFeedback(target) {
+    const element = modalFeedbackElements[target];
+    if (!element) return;
+    element.textContent = '';
+    element.className = `${MODAL_FEEDBACK_BASE} ${MODAL_FEEDBACK_STYLES.info} hidden`;
+}
+
+function updateHostStats() {
+    if (hostCountBadge) {
+        const count = topWebsites.length;
+        const label = count === 1 ? 'hostname' : 'hostnames';
+        hostCountBadge.textContent = `${count} ${label} configured`;
+    }
+}
+
+function updateDoHStats() {
+    if (dohCountBadge) {
+        const count = dnsServers.length;
+        const label = count === 1 ? 'DoH server' : 'DoH servers';
+        dohCountBadge.textContent = `${count} ${label} configured`;
+    }
+}
+
+function resetHostnamesToDefault() {
+    topWebsites = [...DEFAULT_TOP_WEBSITES];
+    persistHostnames();
+    updateHostStats();
+    showModalFeedback('hosts', 'success', 'Restored recommended hostnames.');
+}
+
+function resetDnsServersToDefault() {
+    dnsServers = DEFAULT_DNS_SERVERS.map(cloneServer);
+    persistDnsServers();
+    updateDoHStats();
+    syncRunButtonState();
+    showModalFeedback('doh', 'success', 'Restored curated DoH server list.');
+}
+
+function parseIpList(rawValue) {
+    if (!rawValue) return [];
+    return rawValue
+        .split(/[\n,;]/)
+        .map(entry => entry.trim())
+        .filter(Boolean);
+}
+
 let dnsChart;
 
 let chartData = [];
@@ -155,7 +298,7 @@ function updateChart() {
     const dynamicHeight = Math.max(minHeight, Math.min(maxHeight, validData.length * heightPerServer + 100));
     
     // Update container height
-    const container = chartContainer.querySelector('.chart-container');
+    const container = chartContainer.querySelector('.chart-container') || chartContainer;
     container.style.height = `${dynamicHeight}px`;
 
     // Show chart container
@@ -342,8 +485,16 @@ checkButton.addEventListener('click', async function () {
 async function performDNSTests() {
 
     const totalQueries = topWebsites.length;
+    const totalServers = dnsServers.length;
 
-    for (const server of dnsServers) {
+    if (totalServers === 0) {
+        await updateLoadingMessage('No DoH servers configured. Add at least one server to run the benchmark.');
+        return;
+    }
+
+    for (let index = 0; index < totalServers; index++) {
+        const server = dnsServers[index];
+        await updateLoadingMessage(`Analyzing DNS servers (${index + 1}/${totalServers}): ${server.name}`);
         const speedResults = await Promise.all(topWebsites.map(website => measureDNSSpeed(server.url, website, server.type, server.allowCors)));
 
         // Map each website to its speed result for the current server
@@ -592,21 +743,25 @@ function updateResult(server) {
     }
 
     // Update row with basic information
-        row.innerHTML = `
-        <td class="text-left py-2 px-4 dark:text-gray-300">${server.name} 
-        <span class="cursor-pointer ml-2 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded flex items-center gap-1 transition-all duration-200 hover:-translate-y-0.5 select-none inline-flex" onclick="copyToClipboard('DoH Server URL: ${server.url}' + '\\n' + 'IP Addresses: ${server.ips.join(', ')}', this)" title="Copy server details">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
-            </svg>
-            Copy
-        </span>
-        ${reliabilityBadge}
-        </td>
-        <td class="text-center py-2 px-4 dark:text-gray-300">${minValue}</td>
-        <td class="text-center py-2 px-4 dark:text-gray-300">${medianValue}</td>
-        <td class="text-center py-2 px-4 dark:text-gray-300">${avgValue}</td>
-        <td class="text-center py-2 px-4 dark:text-gray-300">${maxValue}</td>
-    `;
+    row.innerHTML = '';
+
+    const serverCell = document.createElement('td');
+    serverCell.className = 'text-left py-2 px-4 dark:text-gray-300 flex flex-col gap-1';
+    const serverName = document.createElement('span');
+    serverName.textContent = server.name;
+    serverCell.appendChild(serverName);
+    const copyButton = createCopyButton(server);
+    serverCell.appendChild(copyButton);
+    serverCell.insertAdjacentHTML('beforeend', reliabilityBadge);
+    row.appendChild(serverCell);
+
+    const metricValues = [minValue, medianValue, avgValue, maxValue];
+    metricValues.forEach(value => {
+        const cell = document.createElement('td');
+        cell.className = 'text-center py-2 px-4 dark:text-gray-300';
+        cell.textContent = value;
+        row.appendChild(cell);
+    });
 
     // Populate the detailed view with timings for each hostname
     detailsRow.innerHTML = `
@@ -717,11 +872,31 @@ function sortTable(columnIndex) {
     }
 }
 
+function createCopyButton(server) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = "cursor-pointer ml-0 mt-1 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded flex items-center gap-1 transition-all duration-200 hover:-translate-y-0.5 select-none inline-flex w-max";
+    button.innerHTML = `
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1-.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+        </svg>
+        Copy
+    `;
+    const ipList = Array.isArray(server.ips) && server.ips.length ? server.ips.join(', ') : 'Not provided';
+    const copyText = `DoH Server URL: ${server.url}\nIP Addresses: ${ipList}`;
+    button.dataset.copyText = copyText;
+    button.title = "Copy server details";
+    button.addEventListener('click', (event) => {
+        event.stopPropagation();
+        copyToClipboard(button.dataset.copyText, button);
+    });
+    return button;
+}
+
 function copyToClipboard(text, buttonElement) {
-    event.stopPropagation();
     navigator.clipboard.writeText(text).then(() => {
         // Change button state to indicate success
-        buttonElement.className = "cursor-pointer ml-2 px-2 py-1 text-xs bg-green-100 hover:bg-green-200 dark:bg-green-900 dark:hover:bg-green-800 border border-green-400 text-green-700 dark:text-green-300 rounded flex items-center gap-1 transition-all duration-200 select-none inline-flex";
+        buttonElement.className = "cursor-pointer ml-0 mt-1 px-2 py-1 text-xs bg-green-100 hover:bg-green-200 dark:bg-green-900 dark:hover:bg-green-800 border border-green-400 text-green-700 dark:text-green-300 rounded flex items-center gap-1 transition-all duration-200 select-none inline-flex w-max";
         buttonElement.innerHTML = `
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
@@ -731,7 +906,7 @@ function copyToClipboard(text, buttonElement) {
 
         // Revert button state after 2 seconds
         setTimeout(() => {
-            buttonElement.className = "cursor-pointer ml-2 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded flex items-center gap-1 transition-all duration-200 hover:-translate-y-0.5 select-none inline-flex";
+            buttonElement.className = "cursor-pointer ml-0 mt-1 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded flex items-center gap-1 transition-all duration-200 hover:-translate-y-0.5 select-none inline-flex w-max";
             buttonElement.innerHTML = `
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
@@ -742,7 +917,7 @@ function copyToClipboard(text, buttonElement) {
     }).catch(err => {
         console.error('Error in copying text: ', err);
         // Show error state
-        buttonElement.className = "cursor-pointer ml-2 px-2 py-1 text-xs bg-red-100 hover:bg-red-200 dark:bg-red-900 dark:hover:bg-red-800 border border-red-400 text-red-700 dark:text-red-300 rounded flex items-center gap-1 transition-all duration-200 select-none inline-flex";
+        buttonElement.className = "cursor-pointer ml-0 mt-1 px-2 py-1 text-xs bg-red-100 hover:bg-red-200 dark:bg-red-900 dark:hover:bg-red-800 border border-red-400 text-red-700 dark:text-red-300 rounded flex items-center gap-1 transition-all duration-200 select-none inline-flex w-max";
         buttonElement.innerHTML = `
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
@@ -750,7 +925,7 @@ function copyToClipboard(text, buttonElement) {
             Error
         `;
         setTimeout(() => {
-            buttonElement.className = "cursor-pointer ml-2 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded flex items-center gap-1 transition-all duration-200 hover:-translate-y-0.5 select-none inline-flex";
+            buttonElement.className = "cursor-pointer ml-0 mt-1 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 rounded flex items-center gap-1 transition-all duration-200 hover:-translate-y-0.5 select-none inline-flex w-max";
             buttonElement.innerHTML = `
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
@@ -789,6 +964,14 @@ function updateChartVisibility() {
 // JavaScript to handle modal and list manipulation
 document.addEventListener('DOMContentLoaded', function () {
     updateChartVisibility();
+    const showModal = (element) => {
+        element.classList.remove('hidden');
+        element.removeAttribute('aria-hidden');
+    };
+    const hideModal = (element) => {
+        element.classList.add('hidden');
+        element.setAttribute('aria-hidden', 'true');
+    };
     document.getElementById('resultsTable').addEventListener('click', function (event) {
         let row = event.target.closest('tr');
         if (row && !row.classList.contains('details-row')) {
@@ -801,7 +984,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const modal = document.getElementById("websiteModal");
     const btn = document.getElementById("editButton"); // Button that opens the modal
-    const span = document.getElementsByClassName("close")[0];
+    const hostModalCloseButton = modal.querySelector(".close");
     const addBtn = document.getElementById("addHostname");
     const input = document.getElementById("newWebsite");
     const list = document.getElementById("websiteList");
@@ -809,35 +992,44 @@ document.addEventListener('DOMContentLoaded', function () {
     // Function to render the list
     function renderList() {
         list.innerHTML = '';
-        topWebsites.forEach((site, index) => {
-            const li = document.createElement("li");
-            // Updated class list to include border-bottom for better separation
-            li.className = 'px-2 py-1 mb-1 bg-gray-200 rounded flex justify-between items-center border-b border-gray-300 dark:bg-gray-700 dark:border-gray-600';
+        if (topWebsites.length === 0) {
+            const emptyState = document.createElement("li");
+            emptyState.className = 'px-2 py-3 text-sm text-slate-500 dark:text-slate-300';
+            emptyState.textContent = 'No hostnames configured. Use the form below to add some.';
+            list.appendChild(emptyState);
+        } else {
+            topWebsites.forEach((site, index) => {
+                const li = document.createElement("li");
+                li.className = 'px-2 py-2 mb-1 bg-gray-200 rounded flex justify-between items-center border-b border-gray-300 dark:bg-gray-700 dark:border-gray-600';
 
-            const siteText = document.createElement("span");
-            siteText.textContent = site;
-            li.appendChild(siteText);  // Properly append the text content to the list item
+                const siteText = document.createElement("span");
+                siteText.textContent = site;
+                li.appendChild(siteText);
 
-            const removeBtn = document.createElement("button");
-            removeBtn.className = 'bg-red-500 text-white rounded px-2 py-1 hover:bg-red-600 dark:bg-red-700 dark:hover:bg-red-800';
-            removeBtn.textContent = 'Delete';
-            removeBtn.onclick = function () {
-                topWebsites.splice(index, 1);
-                renderList();
-            };
+                const removeBtn = document.createElement("button");
+                removeBtn.className = 'bg-red-500 text-white rounded px-2 py-1 hover:bg-red-600 dark:bg-red-700 dark:hover:bg-red-800';
+                removeBtn.textContent = 'Delete';
+                removeBtn.onclick = function () {
+                    const removed = topWebsites.splice(index, 1);
+                    persistHostnames();
+                    renderList();
+                    showModalFeedback('hosts', 'info', `${removed[0]} removed from the test list.`);
+                };
 
-            li.appendChild(removeBtn);
-            list.appendChild(li);
-        });
-        // Disable the checkButton if topWebsites is empty
-        checkButton.disabled = topWebsites.length === 0;
+                li.appendChild(removeBtn);
+                list.appendChild(li);
+            });
+        }
+        updateHostStats();
+        // Disable the checkButton if we have no hostnames or DoH servers
+        syncRunButtonState();
     }
 
     // Open the modal
     btn.onclick = function () {
-        modal.style.display = "block";
+        showModal(modal);
         renderList();
-    }
+    };
 
     function validateAndExtractHost(input) {
         try {
@@ -858,103 +1050,235 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     }
 
-    // Close the modal
-    span.onclick = function () {
-        modal.style.display = "none";
+    if (hostModalCloseButton) {
+        hostModalCloseButton.onclick = function () {
+            hideModal(modal);
+            clearModalFeedback('hosts');
+        };
     }
 
-    // Add new website
-    addBtn.onclick = function () {
-        const host = validateAndExtractHost(input.value);
-        if (host) {
-            if (!topWebsites.includes(host)) {
-                topWebsites.push(host);
-                renderList();
-            } else {
-                alert("This website is already in the list.");
-            }
-        } else {
-            alert("Please enter a valid URL or hostname.");
-        }
-        input.value = ''; // Clear the input field
+    if (resetHostnamesButton) {
+        resetHostnamesButton.addEventListener('click', () => {
+            resetHostnamesToDefault();
+            renderList();
+        });
     }
+
+    if (input) {
+        input.addEventListener('input', () => clearModalFeedback('hosts'));
+    }
+
+    // Add new website(s)
+    addBtn.onclick = function () {
+        const candidate = input.value.trim();
+        if (!candidate) {
+            showModalFeedback('hosts', 'error', 'Please enter at least one hostname or URL.');
+            return;
+        }
+        const entries = candidate.split(/[\n,;]/).map(entry => entry.trim()).filter(Boolean);
+        if (!entries.length) {
+            showModalFeedback('hosts', 'error', 'Please enter at least one hostname or URL.');
+            return;
+        }
+
+        const added = [];
+        const duplicates = [];
+        const invalid = [];
+
+        entries.forEach(entry => {
+            const host = validateAndExtractHost(entry);
+            if (!host) {
+                invalid.push(entry);
+                return;
+            }
+            if (topWebsites.includes(host)) {
+                duplicates.push(host);
+                return;
+            }
+            topWebsites.push(host);
+            added.push(host);
+        });
+
+        if (added.length) {
+            persistHostnames();
+            renderList();
+        } else {
+            updateHostStats();
+        }
+
+        input.value = '';
+
+        const messageParts = [];
+        let severity = 'info';
+        if (added.length) {
+            severity = 'success';
+            messageParts.push(`${added.length} ${added.length === 1 ? 'hostname' : 'hostnames'} added.`);
+        }
+        if (duplicates.length) {
+            messageParts.push(`${duplicates.length} duplicate ${duplicates.length === 1 ? 'entry was' : 'entries were'} skipped.`);
+        }
+        if (invalid.length) {
+            if (!added.length) {
+                severity = 'error';
+            }
+            messageParts.push(`${invalid.length} invalid ${invalid.length === 1 ? 'entry' : 'entries'} ignored.`);
+        }
+        if (!messageParts.length) {
+            severity = 'error';
+            messageParts.push('No valid hostnames detected. Please double-check your entries.');
+        }
+        showModalFeedback('hosts', severity, messageParts.join(' '));
+    };
 
     // Close the modal when clicking outside of it
-    window.onclick = function (event) {
-        if (event.target === modal) {
-            modal.style.display = "none";
-        }
-    }
 
 
     const dohModal = document.getElementById("dohModal");
     const dohBtn = document.getElementById("editDoHButton");
     const closeDohBtn = dohModal.querySelector(".close");
     const addDoHBtn = document.getElementById("addDoH");
-    const newDoHInput = document.getElementById("newDoH");
     const dohList = document.getElementById("dohList");
 
     // Function to render the DoH servers list
     function renderDoHList() {
         dohList.innerHTML = '';
-        dnsServers.forEach((server, index) => {
-            const li = document.createElement("li");
-            li.className = 'px-2 py-1 mb-1 bg-gray-200 rounded flex justify-between items-center border-b border-gray-300 dark:bg-gray-700 dark:border-gray-600';
+        if (dnsServers.length === 0) {
+            const emptyState = document.createElement("li");
+            emptyState.className = 'px-2 py-3 text-sm text-slate-500 dark:text-slate-300';
+            emptyState.textContent = 'No DoH servers configured yet.';
+            dohList.appendChild(emptyState);
+        } else {
+            dnsServers.forEach((server, index) => {
+                const li = document.createElement("li");
+                li.className = 'px-3 py-2 mb-1 bg-gray-200 rounded border-b border-gray-300 dark:bg-gray-700 dark:border-gray-600 flex flex-col gap-2';
 
-            const serverText = document.createElement("span");
-            serverText.textContent = `${server.name}: ${server.url}`;
-            li.appendChild(serverText);
+                const serverText = document.createElement("div");
+                serverText.className = 'flex flex-col gap-0.5';
+                const methodLabel = (server.type || 'auto').toUpperCase();
+                const corsLabel = server.allowCors ? 'CORS allowed' : 'No CORS';
+                const ipPreview = server.ips && server.ips.length ? server.ips.slice(0, 3).join(', ') + (server.ips.length > 3 ? '…' : '') : null;
+                serverText.innerHTML = `
+                    <span class="font-semibold text-sm">${server.name}</span>
+                    <span class="text-xs text-slate-600 dark:text-slate-300 break-all">${server.url}</span>
+                    <div class="mt-1 flex flex-wrap gap-2 text-[11px]">
+                        <span class="rounded-full border border-slate-300 dark:border-slate-600 px-2 py-0.5 text-slate-700 dark:text-slate-200">${methodLabel}</span>
+                        <span class="rounded-full px-2 py-0.5 ${server.allowCors ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300' : 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'}">${corsLabel}</span>
+                        ${ipPreview ? `<span class="rounded-full border border-slate-300 dark:border-slate-600 px-2 py-0.5 text-slate-600 dark:text-slate-200">${ipPreview}</span>` : ''}
+                    </div>
+                `;
+                li.appendChild(serverText);
 
-            const removeBtn = document.createElement("button");
-            removeBtn.className = 'bg-red-500 text-white rounded px-2 py-1 ml-2 hover:bg-red-600 dark:bg-red-700 dark:hover:bg-red-800';
-            removeBtn.textContent = 'Delete';
-            removeBtn.onclick = function () {
-                dnsServers.splice(index, 1);
-                renderDoHList();
-            };
+                const actionsRow = document.createElement("div");
+                actionsRow.className = 'flex justify-end';
 
-            li.appendChild(removeBtn);
-            dohList.appendChild(li);
-        });
+                const removeBtn = document.createElement("button");
+                removeBtn.className = 'bg-red-500 text-white rounded px-3 py-1 text-xs hover:bg-red-600 dark:bg-red-700 dark:hover:bg-red-800';
+                removeBtn.textContent = 'Delete';
+                removeBtn.onclick = function () {
+                    const removed = dnsServers.splice(index, 1);
+                    persistDnsServers();
+                    renderDoHList();
+                    syncRunButtonState();
+                    showModalFeedback('doh', 'info', `${removed[0].name} removed from the list.`);
+                };
+
+                actionsRow.appendChild(removeBtn);
+                li.appendChild(actionsRow);
+                dohList.appendChild(li);
+            });
+        }
+        updateDoHStats();
     }
 
     dohBtn.onclick = function () {
-        dohModal.style.display = "block";
+        showModal(dohModal);
         renderDoHList();
     };
 
     closeDohBtn.onclick = function () {
-        dohModal.style.display = "none";
+        hideModal(dohModal);
+        clearModalFeedback('doh');
     };
 
-    // Add new DoH server with automatic capability check
-    addDoHBtn.onclick = function () {
-        const serverDetails = newDoHInput.value.split(', '); // Expected format: "Name, URL"
-        if (serverDetails.length >= 2) {
-            const [name, url] = serverDetails;
+    if (resetDoHButton) {
+        resetDoHButton.addEventListener('click', () => {
+            resetDnsServersToDefault();
+            renderDoHList();
+        });
+    }
 
-            // Check if server already exists by URL or name
-            const isDuplicate = dnsServers.some(server => server.url === url || server.name === name);
-            if (!isDuplicate) {
-                // If not duplicate, proceed to check and add the server
-                checkServerCapabilities(name, url);
-            } else {
-                alert("A server with the same name or URL already exists. Please enter a unique name and URL.");
+    [newDoHNameInput, newDoHUrlInput, newDoHIpsInput].forEach(inputField => {
+        if (inputField) {
+            inputField.addEventListener('input', () => clearModalFeedback('doh'));
+        }
+    });
+
+    if (addDoHBtn) {
+        let dohCheckInProgress = false;
+        const defaultAddDoHLabel = addDoHBtn.textContent;
+
+        const setDoHBusyState = (state) => {
+            dohCheckInProgress = state;
+            addDoHBtn.disabled = state;
+            addDoHBtn.textContent = state ? 'Checking…' : defaultAddDoHLabel;
+        };
+
+        // Add new DoH server with automatic capability check
+        addDoHBtn.addEventListener('click', async () => {
+            if (dohCheckInProgress) return;
+            const name = newDoHNameInput.value.trim();
+            const url = newDoHUrlInput.value.trim();
+            const ips = parseIpList(newDoHIpsInput.value);
+
+            if (!name || !url) {
+                showModalFeedback('doh', 'error', 'Please provide both a server name and a DoH endpoint URL.');
+                return;
             }
-        } else {
-            alert("Please enter DoH server details in the correct format: Name, URL");
-        }
-        newDoHInput.value = ''; // Clear the input field
-    };
 
-    window.onclick = function (event) {
-        if (event.target === dohModal) {
-            dohModal.style.display = "none";
+            try {
+                new URL(url);
+            } catch (error) {
+                showModalFeedback('doh', 'error', 'Please provide a valid URL (including https://).');
+                return;
+            }
+
+            const isDuplicate = dnsServers.some(server => server.url === url || server.name === name);
+            if (isDuplicate) {
+                showModalFeedback('doh', 'error', 'A server with the same name or URL already exists.');
+                return;
+            }
+
+            showModalFeedback('doh', 'info', 'Checking server capabilities…');
+            setDoHBusyState(true);
+            try {
+                const result = await checkServerCapabilities({name, url, ips});
+                if (newDoHNameInput) newDoHNameInput.value = '';
+                if (newDoHUrlInput) newDoHUrlInput.value = '';
+                if (newDoHIpsInput) newDoHIpsInput.value = '';
+                renderDoHList();
+                const summary = `Added ${name} using ${result.chosenType.toUpperCase()} ${result.allowCors ? 'with' : 'without'} CORS.`;
+                showModalFeedback('doh', 'success', summary);
+            } catch (error) {
+                showModalFeedback('doh', 'error', error.message || 'Failed to add DoH server.');
+            } finally {
+                setDoHBusyState(false);
+            }
+        });
+    }
+
+    window.addEventListener('click', function (event) {
+        if (event.target === modal) {
+            hideModal(modal);
+            clearModalFeedback('hosts');
         }
-    };
+        if (event.target === dohModal) {
+            hideModal(dohModal);
+            clearModalFeedback('doh');
+        }
+    });
 
     // Function to check server capabilities for CORS and method support
-    async function checkServerCapabilities(name, url) {
+    async function checkServerCapabilities({name, url, ips = []}) {
         const testHostname = 'example.com';
         const dnsQuery = buildDNSQuery(testHostname);
         const usesJsonApi = (() => {
@@ -1041,12 +1365,19 @@ document.addEventListener('DOMContentLoaded', function () {
             allowCors = false;
         }
 
-        if (chosenType) {
-            dnsServers.push({name, url, type: chosenType, allowCors, ips: []});
-            renderDoHList();
-            alert(`Server added. GET: ${getCors.success || getNoCors.success} (CORS: ${getCors.cors}), POST: ${postCors.success} (CORS: ${postCors.cors}). Using ${chosenType.toUpperCase()} with${allowCors ? '' : 'out'} CORS.`);
-        } else {
-            alert('Failed to add server. Neither GET nor POST methods succeeded. Check console for details.');
+        if (!chosenType) {
+            throw new Error('Failed to confirm DoH capabilities. Neither GET nor POST tests succeeded.');
         }
+
+        dnsServers.push({
+            name,
+            url,
+            type: chosenType,
+            allowCors,
+            ips: Array.isArray(ips) ? [...ips] : []
+        });
+        persistDnsServers();
+        syncRunButtonState();
+        return {chosenType, allowCors, getCors, postCors, getNoCors};
     }
 });


### PR DESCRIPTION
## Summary
- migrate the landing page to a Tailwind-based layout with refined hero, results, chart, and footer sections
- overhaul the host and DoH configuration modals with counters, reset buttons, bulk input parsing, inline feedback, and richer server metadata
- add localStorage persistence plus validation helpers, asynchronous DoH capability checks, and remove the abandoned light/dark theme toggle code

## Testing
- Manual: opened index.html in a browser, exercised host/DoH modal flows (add, delete, reset, capability check) and ran a DNS benchmark to verify progress + results rendering
